### PR TITLE
Correção para o data_frame de MLT

### DIFF
--- a/sintetizador/services/synthesis/scenario.py
+++ b/sintetizador/services/synthesis/scenario.py
@@ -480,6 +480,7 @@ class ScenarioSynthetizer:
         mes_inicio = cls._validate_data(dger.mes_inicio_estudo, int, "dger")
         ano_inicio = cls._validate_data(dger.ano_inicio_estudo, int, "dger")
         anos_estudo = cls._validate_data(dger.num_anos_estudo, int, "dger")
+        anos_pos_estudo = cls._validate_data(dger.num_anos_pos_estudo, int, "dger")
         sistema = cls._validate_data(
             cls._get_sistema(uow).custo_deficit, pd.DataFrame, "submercados"
         )
@@ -496,7 +497,7 @@ class ScenarioSynthetizer:
         cfgs = configuracoes["valor"].to_numpy().flatten()[mes_inicio - 1 :]
         datas = pd.date_range(
             datetime(year=ano_inicio - 1, month=1, day=1),
-            datetime(year=ano_inicio + anos_estudo - 1, month=12, day=1),
+            datetime(year=ano_inicio + anos_estudo + anos_pos_estudo - 1, month=12, day=1),
             freq="MS",
         )
         df_mlt = pd.DataFrame(


### PR DESCRIPTION
O cfg considera o período pós estudo no pmo.dat, conforme lido no código da inewave
![t1](https://github.com/rjmalves/sintetizador-newave/assets/142263303/ae1f9026-b9ad-4e6c-b3e4-8f1c5bea6f3f)

Porém o campo "mes" estava sem o período pós, causando erro no sintetizador de que as listas que formam o dicionário devem ser iguais.

