### PR TITLE
scenario.py -> Iterações máximas

### DIFF
--- a/sintetizador/services/synthesis/scenario.py
+++ b/sintetizador/services/synthesis/scenario.py
@@ -1451,7 +1451,6 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        #n_iters = convergencia["iteracao"].max()
         dger = cls._get_dger(uow)
         n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
@@ -1502,7 +1501,6 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        #n_iters = convergencia["iteracao"].max()
         dger = cls._get_dger(uow)
         n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
@@ -1585,7 +1583,6 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        #n_iters = convergencia["iteracao"].max()
         dger = cls._get_dger(uow)
         n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
@@ -1632,7 +1629,6 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        #n_iters = convergencia["iteracao"].max()
         dger = cls._get_dger(uow)
         n_iters = dger.num_max_iteracoes
         dger = cls._get_dger(uow)

--- a/sintetizador/services/synthesis/scenario.py
+++ b/sintetizador/services/synthesis/scenario.py
@@ -1451,7 +1451,9 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        n_iters = convergencia["iteracao"].max()
+        #n_iters = convergencia["iteracao"].max()
+        dger = cls._get_dger(uow)
+        n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
         n_procs = int(Settings().processors)
         with Pool(processes=n_procs) as pool:
@@ -1500,7 +1502,9 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        n_iters = convergencia["iteracao"].max()
+        #n_iters = convergencia["iteracao"].max()
+        dger = cls._get_dger(uow)
+        n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
         n_procs = int(Settings().processors)
         with Pool(processes=n_procs) as pool:
@@ -1581,7 +1585,9 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        n_iters = convergencia["iteracao"].max()
+        #n_iters = convergencia["iteracao"].max()
+        dger = cls._get_dger(uow)
+        n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
         n_procs = int(Settings().processors)
         with Pool(processes=n_procs) as pool:
@@ -1626,7 +1632,11 @@ class ScenarioSynthetizer:
         convergencia = cls._validate_data(
             cls._get_pmo(uow).convergencia, pd.DataFrame, "convergência"
         )
-        n_iters = convergencia["iteracao"].max()
+        #n_iters = convergencia["iteracao"].max()
+        dger = cls._get_dger(uow)
+        n_iters = dger.num_max_iteracoes
+        dger = cls._get_dger(uow)
+        n_iters = dger.num_max_iteracoes
         df_completo = pd.DataFrame()
         n_procs = int(Settings().processors)
         with Pool(processes=n_procs) as pool:


### PR DESCRIPTION
Os arquivos de vazões são criados de acordo com à máxima iteração. No código anterior estava pela convergência, porém pode ser que a convergência termine antes do máximo de iterações ou pode ser que o caso seja terminado antes do máximo apenas para fim de análise dos cenários. Assim, para pegar todo o arquivo de vazaof por exemplo, troquei para máxima iteração.

OBS: enviei o pool request às 21:01 só porque esqueci mesmo de fazer antes, não estou fazendo hora extra. Work-life balance :)