### PR TITLE
Update files.py

### DIFF
--- a/sintetizador/adapters/repository/files.py
+++ b/sintetizador/adapters/repository/files.py
@@ -1535,7 +1535,7 @@ class RawFilesRepository(AbstractFilesRepository):
             ]
 
             n_estagios = (
-                self._numero_estagios_individualizados() + mes_inicio - 1
+                self._numero_estagios_individualizados() - mes_inicio + 2
             )
             n_estagios_th = 12 if parpa == 3 else ordem_maxima
             caminho_arq = join(self.__tmppath, nome_arq)
@@ -1826,7 +1826,7 @@ class RawFilesRepository(AbstractFilesRepository):
             ]
 
             n_estagios = (
-                self._numero_estagios_individualizados() + mes_inicio - 1
+                self._numero_estagios_individualizados() - mes_inicio + 2
             )
             n_estagios_th = 12 if parpa == 3 else ordem_maxima
             if dger.tipo_simulacao_final == 1:


### PR DESCRIPTION
Estava causando um erro de "Length of values (19116000) does not match length of index (19440000) na linha 1882 do scenario.py.

Após investigar, pareceu que o índice de leitura dos estágios do vazaof e vazaos estavam diferentes dos arquivos. Esse commit foi uma tentativa de corrigir isso, pois o sintetizador estava capotando ao fazer a síntese.

Os arquivos geram para o HIB60, por exemplo, até o período 60, em que mesmo para o pmo de fevereiro, por exemplo, o período 1 corresponde à janeiro. (Informação vista no csv do vazaofxxx). Nesse sentido, pensei em deixar ele pegar até o período 60 do vazaof ou pegar de acordo com o período do estudo, que foi a solução implementada. Exemplo de como fica a implementação:

Exemplo para o HIB60:

self._numero_estagios_individualizados() vem como 60.

ANTES:

DECK FEVEREIRO: mes_inicio = 2
Logo: self._numero_estagios_individualizados() + mes_inicio - 1 = 61

DECK NOVEMBRO: mes_inicio = 11
Logo: self._numero_estagios_individualizados() + mes_inicio - 1 = 60 + 11 -1 = 70

DECK NOVEMBRO: mes_inicio = 12
Logo: self._numero_estagios_individualizados() + mes_inicio - 1 = 60 + 12 -1 = 71 

DEPOIS:


DECK FEVEREIRO: mes_inicio = 2
Logo: self._numero_estagios_individualizados() - mes_inicio + 2 = 60

DECK NOVEMBRO: mes_inicio = 11
Logo: self._numero_estagios_individualizados() - mes_inicio + 2 = 60 - 11 + 2 = 51

DECK NOVEMBRO: mes_inicio = 12
Logo: self._numero_estagios_individualizados() - mes_inicio + 2 = 60 - 12 + 2 = 50