### PR TITLE
Bug mês de março

### DIFF
--- a/sintetizador/services/synthesis/operation.py
+++ b/sintetizador/services/synthesis/operation.py
@@ -2244,9 +2244,7 @@ class OperationSynthetizer:
         mes_inicio = cls._validate_data(dger.mes_inicio_estudo, int, "dger")
         starting_date = datetime(ano_inicio, mes_inicio, 1)
         data_starting_date = df["dataInicio"].min().to_pydatetime()
-        month_difference = int(
-            (starting_date - data_starting_date) / timedelta(days=30)
-        )
+        month_difference = starting_date.month - data_starting_date.month
         return month_difference
 
     @classmethod


### PR DESCRIPTION
A prática anterior indicada o seguinte código:
![image](https://github.com/rjmalves/sintetizador-newave/assets/142263303/f996f2b3-3336-470a-a0b4-6ba3f1137a7a)

No entanto, para o mês de Fevereiro com 28 dias, a soma com janeiro, 31 dias, resultava em 59 dias, quando divididos por 30 e aplicado o int(), estavam sendo arredondados para 1 ao invés de 2. Assim, casos de Março estavam deslocados no período. A alteração tem o objetivo de subtrair os meses diretamente, assim trabalhando apenas com inteiros sem necessidade da aproximação.