### PR TITLE
Alteração da verificação do período individualizado

### DIFF
--- a/sintetizador/adapters/repository/files.py
+++ b/sintetizador/adapters/repository/files.py
@@ -1448,8 +1448,8 @@ class RawFilesRepository(AbstractFilesRepository):
         rees = self._validate_data(arq_ree.rees, pd.DataFrame)
         mes_fim_hib = rees["mes_fim_individualizado"].iloc[0]
         ano_fim_hib = rees["ano_fim_individualizado"].iloc[0]
-
-        if mes_fim_hib is not None and ano_fim_hib is not None:
+        if (type(mes_fim_hib) in (int, float) and 
+            type(ano_fim_hib) in (int, float)):
             data_inicio_estudo = datetime(
                 year=ano_inicio,
                 month=mes_inicio,


### PR DESCRIPTION
Para casos REE estava ocorrendo um erro, pois as variáveis mes_fim_hib e ano_fim_hib estavam retornando nan, com isso, o if do None não estava funcionando. 

Dentre as opções, como de definir as variáveis como None em caso de Nan, tentei modificar o if verificando se as variáveis mes_fim_hib e ano_fim_hib são inteiras ou float para prosseguir com o cálculo.